### PR TITLE
Fixed upload_pdf_form permissions problem

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -69,7 +69,7 @@ class Ability
       UserRole::PRODUCTION
     ]).empty?
 
-    can [:upload_pdf, :remove_pdf], Issue
+    can [:upload_pdf_form, :upload_pdf, :remove_pdf], Issue
   end
 
   def grant_publishing_privileges(roles)


### PR DESCRIPTION
Some non-admins were able to see "Upload PDF" link, but it didn't actually work. This should fix it.
