### PR TITLE
Add article-level partial rendering result cache on top of Varnish cache. 

### DIFF
--- a/app/views/frontend_pieces/_article_list.html.erb
+++ b/app/views/frontend_pieces/_article_list.html.erb
@@ -1,27 +1,29 @@
 <% if !articles.blank? %>
   <% for a in articles %>
-    <div class="article-item">
-      <div class="article-info">
-        <%= section_and_primary_tag_link a.meta(:piece) %>
-        <h1 class="headline"><%= link_to a.meta(:headline), a.meta(:frontend_display_path) %></h1>
-        <% if a.meta(:subhead).present? %>
-          <h2 class="subhead"><%= a.meta(:subhead) %></h2>
-        <% end %>
-        <h4 class="byline">
-          By <%= linked_authors_line a.meta(:authors) %>
-          <% if a.meta(:bytitle).present? %>
-            — <%= a.meta(:bytitle).try(:downcase) %>
+    <% cache("frontend_article_partials/#{a.id}") do %>
+      <div class="article-item">
+        <div class="article-info">
+          <%= section_and_primary_tag_link a.meta(:piece) %>
+          <h1 class="headline"><%= link_to a.meta(:headline), a.meta(:frontend_display_path) %></h1>
+          <% if a.meta(:subhead).present? %>
+            <h2 class="subhead"><%= a.meta(:subhead) %></h2>
           <% end %>
-        </h4>
-        <p class="lede"><%= a.meta(:intro) %></p>
-      </div>
+          <h4 class="byline">
+            By <%= linked_authors_line a.meta(:authors) %>
+            <% if a.meta(:bytitle).present? %>
+              — <%= a.meta(:bytitle).try(:downcase) %>
+            <% end %>
+          </h4>
+          <p class="lede"><%= a.meta(:intro) %></p>
+        </div>
 
-      <div class="article-thumbnail">
-        <% if a.meta(:thumbnail_picture).try(:content).try(:url, :thumbnail) %>
-          <img class="thumbnail" src="<%= a.meta(:thumbnail_picture).try(:content).try(:url) %>">
-        <% end %>
+        <div class="article-thumbnail">
+          <% if a.meta(:thumbnail_picture).try(:content).try(:url, :thumbnail) %>
+            <img class="thumbnail" src="<%= a.meta(:thumbnail_picture).try(:content).try(:url) %>">
+          <% end %>
+        </div>
       </div>
-    </div>
+    <% end %>
   <% end %>
 <% else %>
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
 
   # Show full error reports and disable caching.
   config.consider_all_requests_local       = true
-  config.action_controller.perform_caching = false
+  config.action_controller.perform_caching = true
 
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
Since whole-page caches would be frequently invalidated, whereas article-level partials generally stay fresh longer, we should implement article-level caches on top of whole-page caches to improve the rendering performance. Especially vital for searches, for which we are not currently doing whole-page caching (maybe for a good reason, since an article change can potentially invalidate an infinite number of search result pages). 
