### PR TITLE
Article list pages should display total number of matching articles, instead of 20. 

### DIFF
--- a/app/controllers/frontend_authors_controller.rb
+++ b/app/controllers/frontend_authors_controller.rb
@@ -1,7 +1,11 @@
 class FrontendAuthorsController < FrontendController
   def show
     @author = Author.friendly.find(params[:id])
-    @pieces = Piece.where('published_author_ids ~* ?', "\\y#{@author.id}\\y").page(params[:page]).per(20)
+
+    query = Piece.where('published_author_ids ~* ?', "\\y#{@author.id}\\y")
+    @pieces = query.page(params[:page]).per(20)
+    @count = query.count
+    @sections = query.pluck(:published_section_id).to_a.uniq
     @articles = @pieces.map(&:article).map(&:display_version).sort_by(&:created_at).reverse
 
     set_cache_control_headers(24.hours)

--- a/app/controllers/frontend_pieces_controller.rb
+++ b/app/controllers/frontend_pieces_controller.rb
@@ -44,9 +44,13 @@ class FrontendPiecesController < FrontendController
     @query = params[:query].gsub('+', ' ')
 
     if @query.present?
-      @pieces = Piece.search_query(@query).page(params[:page]).per(20)
+      query = Piece.search_query(@query)
+      @pieces = query.page(params[:page]).per(20)
+      @count = query.count
+      @sections = query.pluck(:published_section_id).to_a.uniq
     else
       @pieces = []
+      @count = 0
     end
 
     @articles = @pieces.map(&:article).map(&:latest_published_version)

--- a/app/controllers/frontend_sections_controller.rb
+++ b/app/controllers/frontend_sections_controller.rb
@@ -1,7 +1,11 @@
 class FrontendSectionsController < FrontendController
   def show
     @section = Section.friendly.find(params[:id])
-    @pieces = Piece.where(published_section_id: @section.id).page(params[:page]).per(20)
+
+    query = Piece.where(published_section_id: @section.id)
+    @pieces = query.page(params[:page]).per(20)
+    @count = query.count
+    @sections = query.pluck(:published_section_id).to_a.uniq
     @articles = @pieces.map(&:article).map(&:latest_published_version)
 
     set_cache_control_headers(24.hours)

--- a/app/controllers/frontend_tags_controller.rb
+++ b/app/controllers/frontend_tags_controller.rb
@@ -1,7 +1,12 @@
 class FrontendTagsController < FrontendController
   def show
     @tag = ActsAsTaggableOn::Tag.find_by(slug: params[:id])
-    @pieces = Piece.where('published_tag_ids ~* ?', "\\y#{@tag.id}\\y").page(params[:page]).per(20)
+    raise_404 if @tag.nil?
+
+    query = Piece.where('published_tag_ids ~* ?', "\\y#{@tag.id}\\y")
+    @pieces = query.page(params[:page]).per(20)
+    @count = query.count
+    @sections = query.pluck(:published_section_id).to_a.uniq
     @articles = @pieces.map(&:article).map(&:latest_published_version)
 
     set_cache_control_headers(24.hours)

--- a/app/helpers/frontend_helper.rb
+++ b/app/helpers/frontend_helper.rb
@@ -21,6 +21,10 @@ module FrontendHelper
   def sections(secs)
     secs.uniq!
 
+    if secs.first.is_a? Fixnum
+      secs = secs.map { |i| Section.find(i).name }
+    end
+
     case secs.size
     when 0
       ''

--- a/app/views/frontend_authors/show.html.erb
+++ b/app/views/frontend_authors/show.html.erb
@@ -4,7 +4,12 @@
   </div>
   <div class="author-info">
     <h1><%= @author.name %></h1>
-    <span class="article-count"><%= pluralize @articles.count, 'article' %> in <%= sections @articles.map { |a| a.meta(:section_name) } %></span>
+    <span class="article-count">
+      <%= pluralize @count, 'article' %>
+      <% if @count > 0 %>
+        in <%= sections @sections %>
+      <% end %>
+    </span>
     <div class="author-bio">
       <%= @author.bio.split("\n").map(&method(:simple_format)).join("\n").html_safe rescue '' %>
     </div>

--- a/app/views/frontend_pieces/search.html.erb
+++ b/app/views/frontend_pieces/search.html.erb
@@ -1,6 +1,11 @@
 <div class="tag-header">
   <h1>Searching for "<%= @query %>"</h1>
-  <p class="article-count"><%= pluralize @articles.count, 'article' %> in <%= sections @articles.map { |a| a.meta(:section_name) } %></p>
+  <p class="article-count">
+    <%= pluralize @count, 'article' %>
+    <% if @count > 0 %>
+      in <%= sections @sections %>
+    <% end %>
+  </p>
 </div>
 
 <%= render 'frontend_pieces/article_list', articles: @articles %>

--- a/app/views/frontend_sections/show.html.erb
+++ b/app/views/frontend_sections/show.html.erb
@@ -1,6 +1,11 @@
 <div class="tag-header">
   <h1><%= @section.name %></h1>
-  <p class="article-count"><%= pluralize @articles.count, 'article' %> in <%= sections @articles.map { |a| a.meta(:section_name) } %></p>
+  <p class="article-count">
+    <%= pluralize @count, 'article' %>
+    <% if @count > 0 %>
+      in <%= sections @sections %>
+    <% end %>
+  </p>
 </div>
 
 <%= render 'frontend_pieces/article_list', articles: @articles %>

--- a/app/views/frontend_tags/show.html.erb
+++ b/app/views/frontend_tags/show.html.erb
@@ -1,6 +1,11 @@
 <div class="tag-header">
   <h1>Tagged "<%= @tag %>"</h1>
-  <p class="article-count"><%= pluralize @articles.count, 'article' %> in <%= sections @articles.map { |a| a.meta(:section_name) } %></p>
+  <p class="article-count">
+    <%= pluralize @count, 'article' %>
+    <% if @count > 0 %>
+      in <%= sections @sections %>
+    <% end %>
+  </p>
 </div>
 
 <%= render 'frontend_pieces/article_list', articles: @articles %>


### PR DESCRIPTION
Like on http://tech.ljh.me/search/marathon. 
