### PR TITLE
Fixed #164.

### DIFF
--- a/lib/tasks/prefill.rake
+++ b/lib/tasks/prefill.rake
@@ -85,6 +85,6 @@ namespace :prefill do
     Homepage.destroy_all
     h = Homepage.create(layout: homepage_layout)
 
-    h.publish_ready!
+    h.published!
   end
 end


### PR DESCRIPTION
`rake prefill:create_homepage` now sets homepage status to published
