### PR TITLE
Improve primary tag extraction from headlines during import

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -235,6 +235,7 @@ class Article < AbstractModel
         is_ready_for_print: self.ready_for_print?,
         has_pending_draft: self.has_pending_draft?,
         section_name: self.piece.section.name,
+        primary_tag: self.piece.primary_tag,
         headline: self.headline,
         subhead: self.subhead,
         authors_line: self.authors_line,

--- a/app/tech_parser/legacy_db_parser.rb
+++ b/app/tech_parser/legacy_db_parser.rb
@@ -395,8 +395,7 @@ module TechParser
               pie.slug = "#{parent_archive}-#{tag}-V#{issue.volume}-N#{issue.number}".downcase
             end
 
-            fp = a['headline'].split(':').first
-            pie.primary_tag = fp if (fp =~ /[A-Z ]*/ && a['headline'].split(':').count >= 2)
+            pie.primary_tag = parse_headline_with_tag(a['headline'])[:tag]
 
             pie.created_at = issue.published_at.to_datetime
             pie.updated_at = issue.published_at.to_datetime
@@ -409,18 +408,14 @@ module TechParser
           Article.find_by(id: a['idarticles'].to_i).try(:destroy)
           article = Article.create do |art|
             art.piece_id = art.id = a['idarticles'].to_i
-            art.headline = HTMLEntities.new.decode(a['headline'])
+            art.headline = HTMLEntities.new.decode(
+              parse_headline_with_tag(a['headline'])[:headline])
             art.subhead = HTMLEntities.new.decode(a['subhead'])
             art.author_ids = parse_author_line(a['byline'])
             art.bytitle = HTMLEntities.new.decode(a['bytitle'])
             art.html = a['body']
             art.rank = a['rank'].to_i
             art.lede = HTMLEntities.new.decode(a['lede'])
-
-            fp = a['headline'].split(':').first
-            art.headline = a['headline'].split(':').drop(1).join(':') if (fp =~ /^[A-Z ]*$/ && a['headline'].split(':').count >= 2)
-
-            art.headline = HTMLEntities.new.decode(art.headline)
           end
 
           article.created_at = issue.published_at.to_datetime
@@ -452,6 +447,19 @@ module TechParser
         end
 
         authors.map { |p| Author.find_or_create_by(name: p).id }.join(",")
+      end
+
+      def parse_headline_with_tag(legacy_headline)
+        # If legacy headline looks like "EDITORIAL: MIT was right", then split off "EDITORIAL"
+        # into primary tag.
+        #
+        # Returns a hash with keys :tag and :headline.
+        match = /^([A-Z\'\- ']{4,}):\s(.{3,})$/m.match(legacy_headline)
+        if match
+          {tag: match[1].strip, headline: match[2].strip}
+        else
+          {tag: nil, headline: legacy_headline.strip}
+        end
       end
   end
 end

--- a/app/views/articles/_article_list.html.erb
+++ b/app/views/articles/_article_list.html.erb
@@ -35,8 +35,11 @@
         <span class="slug">
           <a href="<%= article[:latest_version_path] %>"><%= article[:slug] %></a>
         </span>
-        •
-        <%= article[:headline] %></p>
+        <% unless article[:primary_tag].nil? %>
+          • <%= article[:primary_tag] %>
+        <% end %>
+        • <%= article[:headline] %>
+      </p>
       <p>
         <span class="extra-info">
           V<%= article[:issue][:volume] %>


### PR DESCRIPTION
I believe this takes care of the majority of articles with primary tags of the form "EDITORIAL: bla blaha jkl s".

Remaining cases include: 
- articles whose headlines don't have anything other than the primary tag: "CORRECTIONS"
- miscellaneous legacy weirdos that will probably have to be fiddled with manually
