### PR TITLE
Hide publish-pending versions that are older than the currently published version. 

### DIFF
--- a/app/controllers/publishing_controller.rb
+++ b/app/controllers/publishing_controller.rb
@@ -1,7 +1,11 @@
 class PublishingController < ApplicationController
   def dashboard
-    @pending_versions = ArticleVersion.web_ready.order('created_at DESC').uniq { |v| v.article_id }
+    @pending_versions = ArticleVersion.web_ready.order('created_at DESC').to_a
+    @pending_versions = @pending_versions.select do |v|
+      v.article.latest_published_version.nil? || v.created_at > v.article.latest_published_version.created_at
+    end
+
     @pending_images = Image.web_ready.order('created_at DESC')
-    @pending_homepages = Homepage.publish_ready.order('updated_at DESC')
+    @pending_homepages = Homepage.publish_ready.where('created_at >= ?', Homepage.latest_published.created_at).order('created_at DESC')
   end
 end

--- a/app/views/publishing/dashboard.html.erb
+++ b/app/views/publishing/dashboard.html.erb
@@ -45,7 +45,7 @@
     <% if !@pending_versions.blank? %>
       <% for v in @pending_versions %>
         <tr>
-          <td><%= v.article.headline %></td>
+          <td><%= v.meta(:headline) %></td>
           <td>
             <% if v.article.latest_published_version.nil? %>
               Never Published


### PR DESCRIPTION
Suppose we have version A, B, C for an article/homepage, and we published C. At this point, A and B should not be displayed in the to-be-published list. 
