### PR TITLE
Add titles to CMS pages, addressing #536

### DIFF
--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -7,13 +7,13 @@ class AdsController < ApplicationController
   respond_to :html
 
   def index
-    @title = 'Ads'
+    @title = "Ads"
     @ads = Ad.order('start_date DESC').all
     respond_with(@ads)
   end
 
   def show
-    @title = 'Ad: ' + @ad.name
+    @title = "Ad: " + @ad.name
     respond_with(@ad)
   end
 
@@ -24,7 +24,7 @@ class AdsController < ApplicationController
   end
 
   def edit
-    @title = 'Ad: ' + @ad.name
+    @title = "Ad: " + @ad.name
   end
 
   def create

--- a/app/controllers/ads_controller.rb
+++ b/app/controllers/ads_controller.rb
@@ -7,20 +7,24 @@ class AdsController < ApplicationController
   respond_to :html
 
   def index
+    @title = 'Ads'
     @ads = Ad.order('start_date DESC').all
     respond_with(@ads)
   end
 
   def show
+    @title = 'Ad: ' + @ad.name
     respond_with(@ad)
   end
 
   def new
+    @title = "New Ad"
     @ad = Ad.new
     respond_with(@ad)
   end
 
   def edit
+    @title = 'Ad: ' + @ad.name
   end
 
   def create

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -11,6 +11,7 @@ class ArticlesController < ApplicationController
     # Otherwise
     #   articles are searched for matching headline or other metadata.
 
+    @title = 'Articles'
     @page = (params[:page].presence || 1).to_i
 
     if params[:q].blank?
@@ -51,6 +52,7 @@ class ArticlesController < ApplicationController
   end
 
   def new
+    @title = "New Article"
     @article = Article.new
     @draft = Draft.new
   end
@@ -88,6 +90,7 @@ class ArticlesController < ApplicationController
 
   def edit
     @draft = @article.drafts.find(params[:draft_id])
+    @title = "Edit '" + @draft.headline.split.first(2).join(' ') + "...'" # use first 2 words of last draft's headline in title
     gon.prefilled_authors = @draft.authors.map { |a| a.as_json(only: [:id, :name]) }
   end
 

--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -11,7 +11,7 @@ class ArticlesController < ApplicationController
     # Otherwise
     #   articles are searched for matching headline or other metadata.
 
-    @title = 'Articles'
+    @title = "Articles"
     @page = (params[:page].presence || 1).to_i
 
     if params[:q].blank?

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -4,6 +4,7 @@ class AuthorsController < ApplicationController
   load_and_authorize_resource
 
   def index
+    @title = 'Authors'
     @authors = Author.all
 
     respond_to do |format|
@@ -13,14 +14,17 @@ class AuthorsController < ApplicationController
   end
 
   def show
+    @title = @author.name 
     @articles = @author.drafts.map(&:article).uniq
   end
 
   def new
+    @title = 'Create Author'
     @author = Author.new
   end
 
   def edit
+    @title = @author.name 
   end
 
   def create

--- a/app/controllers/authors_controller.rb
+++ b/app/controllers/authors_controller.rb
@@ -4,7 +4,7 @@ class AuthorsController < ApplicationController
   load_and_authorize_resource
 
   def index
-    @title = 'Authors'
+    @title = "Authors"
     @authors = Author.all
 
     respond_to do |format|
@@ -19,7 +19,7 @@ class AuthorsController < ApplicationController
   end
 
   def new
-    @title = 'Create Author'
+    @title = "Create Author"
     @author = Author.new
   end
 

--- a/app/controllers/drafts_controller.rb
+++ b/app/controllers/drafts_controller.rb
@@ -9,6 +9,7 @@ class DraftsController < ApplicationController
   def index
     @article = Article.find(params[:article_id])
     @drafts = @article.drafts.order('created_at ASC')
+    @title = @drafts.first.headline.split.first(3).join(' ') + '...' # display first 3 words of headline in title
 
     respond_to do |f|
       f.html

--- a/app/controllers/homepages_controller.rb
+++ b/app/controllers/homepages_controller.rb
@@ -4,10 +4,12 @@ class HomepagesController < ApplicationController
   load_and_authorize_resource only: [:index, :show, :update, :duplicate, :publish]
 
   def index
+    @title = 'Homepages'
     @homepages = Homepage.order('created_at DESC').limit(100)
   end
 
   def show
+    @title = 'Homepage ' + @homepage.id.to_s
     @homepage = Homepage.find(params[:id])
     @latest_issue = Issue.latest_published
 

--- a/app/controllers/homepages_controller.rb
+++ b/app/controllers/homepages_controller.rb
@@ -4,12 +4,12 @@ class HomepagesController < ApplicationController
   load_and_authorize_resource only: [:index, :show, :update, :duplicate, :publish]
 
   def index
-    @title = 'Homepages'
+    @title = "Homepages"
     @homepages = Homepage.order('created_at DESC').limit(100)
   end
 
   def show
-    @title = 'Homepage ' + @homepage.id.to_s
+    @title = "Homepage " + @homepage.id.to_s
     @homepage = Homepage.find(params[:id])
     @latest_issue = Issue.latest_published
 

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,7 +4,7 @@ class ImagesController < ApplicationController
   load_and_authorize_resource except: [:create]
 
   def index
-    @title = 'Images'
+    @title = "Images"
     respond_to do |format|
       format.html
       format.json do

--- a/app/controllers/images_controller.rb
+++ b/app/controllers/images_controller.rb
@@ -4,6 +4,7 @@ class ImagesController < ApplicationController
   load_and_authorize_resource except: [:create]
 
   def index
+    @title = 'Images'
     respond_to do |format|
       format.html
       format.json do
@@ -20,6 +21,7 @@ class ImagesController < ApplicationController
   end
 
   def show
+    @title = "View Image: '" + @image.caption.split.first(2).join(' ') + "...'"
     respond_to do |f|
       f.html
       f.json { render json: {image: @image.as_react(current_ability)} }
@@ -27,6 +29,7 @@ class ImagesController < ApplicationController
   end
 
   def new
+    @title = "New Image"
     @image = Image.new
     prepare_authors_json
   end
@@ -62,6 +65,7 @@ class ImagesController < ApplicationController
   end
 
   def edit
+    @title = "Edit Image: '" + @image.caption.split.first(2).join(' ') + "...'" # use old caption in title
     prepare_authors_json
   end
 

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -4,7 +4,7 @@ class IssuesController < ApplicationController
   respond_to :html
 
   def index
-    @title = 'Issues'
+    @title = "Issues"
     @filter_volume = params[:filter_volume]
     @issues = Issue.all
     @issues = @issues.where(volume: @filter_volume) if @filter_volume.present?
@@ -14,7 +14,7 @@ class IssuesController < ApplicationController
   end
 
   def show
-    @title = 'V' + @issue.volume.to_s + ' N' + @issue.number.to_s 
+    @title = "V" + @issue.volume.to_s + " N" + @issue.number.to_s 
     @articles_by_sections = @issue.articles.reorder('section_id ASC').group_by { |x| x.section.name }
     @images = @issue.images
   end

--- a/app/controllers/issues_controller.rb
+++ b/app/controllers/issues_controller.rb
@@ -4,6 +4,7 @@ class IssuesController < ApplicationController
   respond_to :html
 
   def index
+    @title = 'Issues'
     @filter_volume = params[:filter_volume]
     @issues = Issue.all
     @issues = @issues.where(volume: @filter_volume) if @filter_volume.present?
@@ -13,6 +14,7 @@ class IssuesController < ApplicationController
   end
 
   def show
+    @title = 'V' + @issue.volume.to_s + ' N' + @issue.number.to_s 
     @articles_by_sections = @issue.articles.reorder('section_id ASC').group_by { |x| x.section.name }
     @images = @issue.images
   end

--- a/app/controllers/publishing_controller.rb
+++ b/app/controllers/publishing_controller.rb
@@ -1,6 +1,7 @@
 class PublishingController < ApplicationController
 
   def dashboard
+    @title = "Publish"
     authorize! :show, :dashboard
 
     @pending_homepages = Homepage.publish_ready.where('created_at >= ?', Homepage.latest_published.created_at).order('created_at DESC')

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -6,7 +6,7 @@ class SectionsController < ApplicationController
   respond_to :html
 
   def index
-    @title = 'Sections'
+    @title = "Sections"
     @sections = Section.all
   end
 

--- a/app/controllers/sections_controller.rb
+++ b/app/controllers/sections_controller.rb
@@ -6,10 +6,12 @@ class SectionsController < ApplicationController
   respond_to :html
 
   def index
+    @title = 'Sections'
     @sections = Section.all
   end
 
   def show
+    @title = @section.name
   end
 
   def new

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,7 +6,7 @@ class UsersController < ApplicationController
   respond_to :html
 
   def index
-    @title = 'Users'
+    @title = "Users"
     @users = User.all.order('name ASC')
   end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -6,6 +6,7 @@ class UsersController < ApplicationController
   respond_to :html
 
   def index
+    @title = 'Users'
     @users = User.all.order('name ASC')
   end
 

--- a/app/views/frontend/issue_index.haml
+++ b/app/views/frontend/issue_index.haml
@@ -1,4 +1,4 @@
-- Issue.reorder(:volume).last.volume.downto(1) do |i|
+- Issue.published.reorder(:volume).last.volume.downto(1) do |i|
   %h2 Volume #{i}
-  - Issue.where(volume: i).reorder(:number).each do |ii|
+  - Issue.published.where(volume: i).reorder(:number).each do |ii|
     = link_to ii.number, frontend_issue_path(ii.volume, ii.number), class: 'issue'

--- a/app/views/frontend/issue_index.haml
+++ b/app/views/frontend/issue_index.haml
@@ -1,4 +1,4 @@
-- Issue.published.reorder(:volume).last.volume.downto(1) do |i|
+- Issue.reorder(:volume).last.volume.downto(1) do |i|
   %h2 Volume #{i}
-  - Issue.published.where(volume: i).reorder(:number).each do |ii|
+  - Issue.where(volume: i).reorder(:number).each do |ii|
     = link_to ii.number, frontend_issue_path(ii.volume, ii.number), class: 'issue'

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -10,7 +10,8 @@
     %meta{charset: "utf-8"}/
     %meta{content: "IE=Edge,chrome=1", "http-equiv" => "X-UA-Compatible"}/
     %meta{content: "width=device-width, initial-scale=1.0", name: "viewport"}/
-    %title The Tech#{!@title.blank? ? " | #{@title}" : ""}
+    %title #{!@title.blank? ? "#{@title} |" : ""} TT CMS
+    / %title The Tech#{!@title.blank? ? " | #{@title}" : ""}
     = csrf_meta_tags
     / Le HTML5 shim, for IE6-8 support of HTML elements
     /[if lt IE 9]

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,6 @@
     %meta{content: "IE=Edge,chrome=1", "http-equiv" => "X-UA-Compatible"}/
     %meta{content: "width=device-width, initial-scale=1.0", name: "viewport"}/
     %title #{!@title.blank? ? "#{@title} |" : ""} TT CMS
-    / %title The Tech#{!@title.blank? ? " | #{@title}" : ""}
     = csrf_meta_tags
     / Le HTML5 shim, for IE6-8 support of HTML elements
     /[if lt IE 9]


### PR DESCRIPTION
These changes define the title strings for all pages in the CMS in order to address #536, and also change the format of the title to `<contextual title> | TT CMS` in order to clearly show the difference between the frontend and backend.