### PR TITLE
show only published issues in list, fix #535

### DIFF
--- a/app/views/frontend/issue_index.haml
+++ b/app/views/frontend/issue_index.haml
@@ -1,4 +1,4 @@
-- Issue.reorder(:volume).last.volume.downto(1) do |i|
+- Issue.published.reorder(:volume).last.volume.downto(1) do |i|
   %h2 Volume #{i}
-  - Issue.where(volume: i).reorder(:number).each do |ii|
+  - Issue.published.where(volume: i).reorder(:number).each do |ii|
     = link_to ii.number, frontend_issue_path(ii.volume, ii.number), class: 'issue'


### PR DESCRIPTION
This fixes #535 by using the preexisting `published` scope on issues to immediately filter the query for all issues to only those that have been published. I believe this should just make the issue appear in the list of all issues at midnight on the day that issue is to be published, which may not be ideal, but also is maybe good enough? I'm not familiar enough with the process yet to be sure.