### PR TITLE
[Bug] [Fixed] changed widths of article-img elements to fit within parent div

### DIFF
--- a/app/assets/stylesheets/frontend/frontend_actions.css.scss
+++ b/app/assets/stylesheets/frontend/frontend_actions.css.scss
@@ -2429,6 +2429,7 @@ figcaption span.attribution a {
 figure.article-img {
   font-size: 1.2em;
   margin-bottom: 0;
+  width: 92.5% !important;
 
   a {
     text-decoration: none;


### PR DESCRIPTION
Changed "width" css attribute to account for margin that was cutting off right side of article images