### PR TITLE
Allow biz to create ads

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,6 +46,7 @@ class Ability
 
     if roles.include? :business_staff
       can :manage, :ads
+      can :manage, Ad
     end
 
   end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -39,6 +39,9 @@ Rails.application.configure do
   # Devise
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
 
+  # hopefully this will let it automatically reload on changes
+  config.file_watcher = ActiveSupport::FileUpdateChecker
+
   config.serve_static_assets = true
 
   config.generators do |g|


### PR DESCRIPTION
This seems to have been the intended behavior all along, but I think there was a bug. Business should now be able to manage (create, destroy, etc) ads.