### PR TITLE
Update Gemfile and Gemfile.lock to remove git protocol reference

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ gem 'js-routes'
 gem 'kaminari'
 gem 'less-rails', '~> 2.7.0'
 gem 'message_bus'
-gem 'mimemagic', github: 'mimemagicrb/mimemagic', ref: 'd5ebc0cd846dcc68142622c76ad71d021768b7c2' # this is v0.3.3
+gem 'mimemagic', git: 'https://github.com/mimemagicrb/mimemagic.git', ref: 'd5ebc0cd846dcc68142622c76ad71d021768b7c2' # this is v0.3.3
 gem 'mysql2'
 gem 'neat', '~> 1.7.1'
 gem 'nokogiri'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,5 +1,5 @@
 GIT
-  remote: git://github.com/mimemagicrb/mimemagic.git
+  remote: https://github.com/mimemagicrb/mimemagic.git
   revision: d5ebc0cd846dcc68142622c76ad71d021768b7c2
   ref: d5ebc0cd846dcc68142622c76ad71d021768b7c2
   specs:


### PR DESCRIPTION
Replace implicit git:// protocol with explicit https://.

Bundler 1.17 expands the github: shorthand to git://.

GitHub disabled the git:// protocol in March 2022 ( https://github.blog/security/application-security/improving-git-protocol-security-github/#no-more-unauthenticated-git ). 

Update the pin in Gemfile and Gemfile.lock for mimemagic to explicitly use https.

Verified on the thetech staging image that the staging bundles at least seem to build and install correctly with this change in place:

```
 sudo docker run --rm --network host -v /tmp/ttfix:/fix:ro --entrypoint bash dokku/staging:latest -lc '
>   rm -rf /tmp/bt && mkdir -p /tmp/bt && cd /tmp/bt
>   cp /fix/Gemfile /fix/Gemfile.lock .
>   export HOME=/tmp/bt PATH=/app/vendor/ruby-2.6.5/bin:$PATH
>   unset BUNDLE_DEPLOYMENT BUNDLE_PATH BUNDLE_WITHOUT BUNDLE_BIN BUNDLE_APP_CONFIG BUNDLE_GLOBAL_PATH_APPENDS_RUBY_SCOPE
>   export BUNDLE_GEMFILE=/tmp/bt/Gemfile
>   bundle config --local frozen true
>   echo "=== frozen agreement check ==="
>   bundle lock 2>&1 | tail -8; echo "lock exit: ${PIPESTATUS[0]}"
>   echo "=== real install (native compiles expected; this is the slow one) ==="
>   bundle install --jobs 4 2>&1 | tail -30; echo "install exit: ${PIPESTATUS[0]}"
> '
mesg: ttyname failed: Inappropriate ioctl for device

You are replacing the current local value of frozen, which is currently nil
=== frozen agreement check ===
Warning: the running version of Bundler (1.17.2) is older than the version that created the lockfile (1.17.3). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rails-assets.org/...
Fetching gem metadata from https://rubygems.org/........
Fetching https://github.com/mimemagicrb/mimemagic.git
Fetching gem metadata from https://rails-assets.org/...
Writing lockfile to /tmp/bt/Gemfile.lock
lock exit: 0
=== real install (native compiles expected; this is the slow one) ===
  `public-read`.
For a walkthrough of upgrading from 4 to 5 and aws-sdk >= 2.0 you can watch
http://rubythursday.com/episodes/ruby-snack-27-upgrade-paperclip-and-aws-sdk-in-prep-for-rails-5
Post-install message from twitter-bootstrap-rails:
Important: You may need to add a javascript runtime to your Gemfile in order for bootstrap's LESS files to compile to CSS. 
**********************************************

ExecJS supports these runtimes:

therubyracer - Google V8 embedded within Ruby

therubyrhino - Mozilla Rhino embedded within JRuby

Node.js

Apple JavaScriptCore - Included with Mac OS X

Microsoft Windows Script Host (JScript)

**********************************************
Warning: the gem 'rails-assets-jquery' was found in multiple sources.
Installed from: https://rails-assets.org/
Also found in:
  * https://rubygems.org/
You should add a source requirement to restrict this gem to your preferred source.
For example:
    gem 'rails-assets-jquery', :source => 'https://rails-assets.org/'
Then uninstall the gem 'rails-assets-jquery' (or delete all bundled gems) and then install again.
install exit: 0
```