### PR TITLE
Minimal calendar update for 2026

### DIFF
--- a/app/views/frontend_static_pages/ads/_calendar.html.erb
+++ b/app/views/frontend_static_pages/ads/_calendar.html.erb
@@ -6,7 +6,7 @@
 <!-- ************************************************** -->
 <table class="year">
 <tr>
-<tr class="year"><th colspan="2" class="year">2025</th></tr>
+<tr class="year"><th colspan="2" class="year">2026</th></tr>
 <td id="keycell">
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
 <table id="key"><tr><td><span id="issuekey">&#9632;</span>&nbsp;issue dates</td></tr><tr><td><span id="specialkey">&#9632;</span>&nbsp;special issues</td></tr></table>
@@ -17,26 +17,25 @@
 <!-- )))))                                                     ((((( -->
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
 <!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month sat">1</td>
-<tr class="month"><td class="month sun">2</td><td class="month mon">3</td><td class="month tue">4</td><td class="month wed">5</td><td class="month thu issue">6</td><td class="month fri">7</td><td class="month sat">8</td>
-<tr class="month"><td class="month sun">9</td><td class="month mon">10</td><td class="month tue">11</td><td class="month wed">12</td><td class="month thu">13</td><td class="month fri">14</td><td class="month sat">15</td>
-<tr class="month"><td class="month sun">16</td><td class="month mon">17</td><td class="month tue">18</td><td class="month wed">19</td><td class="month thu issue">20</td><td class="month fri">21</td><td class="month sat">22</td>
-<tr class="month"><td class="month sun">23</td><td class="month mon">24</td><td class="month tue">25</td><td class="month wed">26</td><td class="month thu">27</td><td class="month fri">28</td><td class="month noday">&nbsp;</td>
+<tr class="month"><td class="month sun">1</td><td class="month mon">2</td><td class="month tue">3</td><td class="month wed">4</td><td class="month thu">5</td><td class="month fri">6</td><td class="month sat">7</td>
+<tr class="month"><td class="month sun">8</td><td class="month mon">9</td><td class="month tue">10</td><td class="month wed">11</td><td class="month thu special">12</td><td class="month fri">13</td><td class="month sat">14</td>
+<tr class="month"><td class="month sun">15</td><td class="month mon">16</td><td class="month tue">17</td><td class="month wed">18</td><td class="month thu issue">19</td><td class="month fri">20</td><td class="month sat">21</td>
+<tr class="month"><td class="month sun">22</td><td class="month mon">23</td><td class="month tue">24</td><td class="month wed">25</td><td class="month thu">26</td><td class="month fri">27</td><td class="month sat">28</td>
 </table>
 </td>
-</tr><tr>
+</tr>
+<tr>
 <td class="year"><table class="month">
 <tr><th colspan="7" class="month">March</th></tr>
 <tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
 <!-- )))))                                                     ((((( -->
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
 <!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month sat">1</td>
-<tr class="month"><td class="month sun">2</td><td class="month mon">3</td><td class="month tue">4</td><td class="month wed">5</td><td class="month thu issue">6</td><td class="month fri">7</td><td class="month sat">8</td>
-<tr class="month"><td class="month sun">9</td><td class="month mon">10</td><td class="month tue">11</td><td class="month wed">12</td><td class="month thu">13</td><td class="month fri">14</td><td class="month sat">15</td>
-<tr class="month"><td class="month sun">16</td><td class="month mon">17</td><td class="month tue">18</td><td class="month wed">19</td><td class="month thu issue">20</td><td class="month fri">21</td><td class="month sat">22</td>
-<tr class="month"><td class="month sun">23</td><td class="month mon">24</td><td class="month tue">25</td><td class="month wed">26</td><td class="month thu">27</td><td class="month fri">28</td><td class="month sat">29</td>
-<tr class="month"><td class="month sun">30</td><td class="month mon">31</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
+<tr class="month"><td class="month sun">1</td><td class="month mon">2</td><td class="month tue">3</td><td class="month wed">4</td><td class="month thu issue">5</td><td class="month fri">6</td><td class="month sat">7</td>
+<tr class="month"><td class="month sun">8</td><td class="month mon">9</td><td class="month tue">10</td><td class="month wed">11</td><td class="month thu">12</td><td class="month fri">13</td><td class="month sat">14</td>
+<tr class="month"><td class="month sun">15</td><td class="month mon">16</td><td class="month tue">17</td><td class="month wed">18</td><td class="month thu issue">19</td><td class="month fri">20</td><td class="month sat">21</td>
+<tr class="month"><td class="month sun">22</td><td class="month mon">23</td><td class="month tue">24</td><td class="month wed">25</td><td class="month thu">26</td><td class="month fri">27</td><td class="month sat">28</td>
+<tr class="month"><td class="month sun">29</td><td class="month mon">30</td><td class="month tue">31</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
 </table>
 </td>
 <td class="year"><table class="month">
@@ -45,25 +44,27 @@
 <!-- )))))                                                     ((((( -->
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
 <!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month tue">1</td><td class="month wed">2</td><td class="month thu issue">3</td><td class="month fri">4</td><td class="month sat">5</td>
-<tr class="month"><td class="month sun">6</td><td class="month mon">7</td><td class="month tue">8</td><td class="month wed">9</td><td class="month thu">10</td><td class="month fri">11</td><td class="month sat">12</td>
-<tr class="month"><td class="month sun">13</td><td class="month mon">14</td><td class="month tue">15</td><td class="month wed">16</td><td class="month thu special">17</td><td class="month fri">18</td><td class="month sat">19</td>
-<tr class="month"><td class="month sun">20</td><td class="month mon">21</td><td class="month tue">22</td><td class="month wed">23</td><td class="month thu">24</td><td class="month fri">25</td><td class="month sat">26</td>
-<tr class="month"><td class="month sun">27</td><td class="month mon">28</td><td class="month tue">29</td><td class="month wed">30</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
+<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month wed">1</td><td class="month thu special">2</td><td class="month fri">3</td><td class="month sat">4</td>
+<tr class="month"><td class="month sun">5</td><td class="month mon">6</td><td class="month tue">7</td><td class="month wed">8</td><td class="month thu">9</td><td class="month fri">10</td><td class="month sat">11</td>
+<tr class="month"><td class="month sun">12</td><td class="month mon">13</td><td class="month tue">14</td><td class="month wed">15</td><td class="month thu special">16</td><td class="month fri">17</td><td class="month sat">18</td>
+<tr class="month"><td class="month sun">19</td><td class="month mon">20</td><td class="month tue">21</td><td class="month wed">22</td><td class="month thu">23</td><td class="month fri">24</td><td class="month sat">25</td>
+<tr class="month"><td class="month sun">26</td><td class="month mon">27</td><td class="month tue">28</td><td class="month wed">29</td><td class="month thu issue">30</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
 </table>
 </td>
-</tr><tr>
+</tr>
+<tr>
 <td class="year"><table class="month">
 <tr><th colspan="7" class="month">May</th></tr>
 <tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
 <!-- )))))                                                     ((((( -->
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
 <!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month thu issue">1</td><td class="month fri">2</td><td class="month sat">3</td>
-<tr class="month"><td class="month sun">4</td><td class="month mon">5</td><td class="month tue">6</td><td class="month wed">7</td><td class="month thu">8</td><td class="month fri">9</td><td class="month sat">10</td>
-<tr class="month"><td class="month sun">11</td><td class="month mon">12</td><td class="month tue">13</td><td class="month wed">14</td><td class="month thu issue">15</td><td class="month fri">16</td><td class="month sat">17</td>
-<tr class="month"><td class="month sun">18</td><td class="month mon">19</td><td class="month tue">20</td><td class="month wed">21</td><td class="month thu">22</td><td class="month fri">23</td><td class="month sat">24</td>
-<tr class="month"><td class="month sun">25</td><td class="month mon">26</td><td class="month tue">27</td><td class="month wed">28</td><td class="month thu special">29</td><td class="month fri">30</td><td class="month sat">31</td>
+<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month fri">1</td><td class="month sat">2</td>
+<tr class="month"><td class="month sun">3</td><td class="month mon">4</td><td class="month tue">5</td><td class="month wed">6</td><td class="month thu">7</td><td class="month fri">8</td><td class="month sat">9</td>
+<tr class="month"><td class="month sun">10</td><td class="month mon">11</td><td class="month tue">12</td><td class="month wed">13</td><td class="month thu issue">14</td><td class="month fri">15</td><td class="month sat">16</td>
+<tr class="month"><td class="month sun">17</td><td class="month mon">18</td><td class="month tue">19</td><td class="month wed">20</td><td class="month thu">21</td><td class="month fri">22</td><td class="month sat">23</td>
+<tr class="month"><td class="month sun">24</td><td class="month mon">25</td><td class="month tue">26</td><td class="month wed">27</td><td class="month thu special">28</td><td class="month fri">29</td><td class="month sat">30</td>
+<tr class="month"><td class="month sun">31</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
 </table>
 </td>
 <td class="year"><table class="month">
@@ -72,25 +73,26 @@
 <!-- )))))                                                     ((((( -->
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
 <!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month sun">1</td><td class="month mon">2</td><td class="month tue">3</td><td class="month wed">4</td><td class="month thu">5</td><td class="month fri">6</td><td class="month sat">7</td>
-<tr class="month"><td class="month sun">8</td><td class="month mon">9</td><td class="month tue">10</td><td class="month wed">11</td><td class="month thu issue">12</td><td class="month fri">13</td><td class="month sat">14</td>
-<tr class="month"><td class="month sun">15</td><td class="month mon">16</td><td class="month tue">17</td><td class="month wed">18</td><td class="month thu">19</td><td class="month fri">20</td><td class="month sat">21</td>
-<tr class="month"><td class="month sun">22</td><td class="month mon">23</td><td class="month tue">24</td><td class="month wed">25</td><td class="month thu">26</td><td class="month fri">27</td><td class="month sat">28</td>
-<tr class="month"><td class="month sun">29</td><td class="month mon">30</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
+<tr class="month"><td class="month noday">&nbsp;</td><td class="month mon">1</td><td class="month tue">2</td><td class="month wed">3</td><td class="month thu">4</td><td class="month fri">5</td><td class="month sat">6</td>
+<tr class="month"><td class="month sun">7</td><td class="month mon">8</td><td class="month tue">9</td><td class="month wed">10</td><td class="month thu issue">11</td><td class="month fri">12</td><td class="month sat">13</td>
+<tr class="month"><td class="month sun">14</td><td class="month mon">15</td><td class="month tue">16</td><td class="month wed">17</td><td class="month thu">18</td><td class="month fri">19</td><td class="month sat">20</td>
+<tr class="month"><td class="month sun">21</td><td class="month mon">22</td><td class="month tue">23</td><td class="month wed">24</td><td class="month thu">25</td><td class="month fri">26</td><td class="month sat">27</td>
+<tr class="month"><td class="month sun">28</td><td class="month mon">29</td><td class="month tue">30</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
 </table>
 </td>
-</tr><tr>
+</tr>
+<tr>
 <td class="year"><table class="month">
 <tr><th colspan="7" class="month">July</th></tr>
 <tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
 <!-- )))))                                                     ((((( -->
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
 <!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month tue">1</td><td class="month wed">2</td><td class="month thu">3</td><td class="month fri">4</td><td class="month sat">5</td>
-<tr class="month"><td class="month sun">6</td><td class="month mon">7</td><td class="month tue">8</td><td class="month wed">9</td><td class="month thu issue">10</td><td class="month fri">11</td><td class="month sat">12</td>
-<tr class="month"><td class="month sun">13</td><td class="month mon">14</td><td class="month tue">15</td><td class="month wed">16</td><td class="month thu">17</td><td class="month fri">18</td><td class="month sat">19</td>
-<tr class="month"><td class="month sun">20</td><td class="month mon">21</td><td class="month tue">22</td><td class="month wed">23</td><td class="month thu">24</td><td class="month fri">25</td><td class="month sat">26</td>
-<tr class="month"><td class="month sun">27</td><td class="month mon">28</td><td class="month tue">29</td><td class="month wed">30</td><td class="month thu">31</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
+<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month wed">1</td><td class="month thu">2</td><td class="month fri">3</td><td class="month sat">4</td>
+<tr class="month"><td class="month sun">5</td><td class="month mon">6</td><td class="month tue">7</td><td class="month wed">8</td><td class="month thu issue">9</td><td class="month fri">10</td><td class="month sat">11</td>
+<tr class="month"><td class="month sun">12</td><td class="month mon">13</td><td class="month tue">14</td><td class="month wed">15</td><td class="month thu">16</td><td class="month fri">17</td><td class="month sat">18</td>
+<tr class="month"><td class="month sun">19</td><td class="month mon">20</td><td class="month tue">21</td><td class="month wed">22</td><td class="month thu">23</td><td class="month fri">24</td><td class="month sat">25</td>
+<tr class="month"><td class="month sun">26</td><td class="month mon">27</td><td class="month tue">28</td><td class="month wed">29</td><td class="month thu">30</td><td class="month fri">31</td><td class="month noday">&nbsp;</td>
 </table>
 </td>
 <td class="year"><table class="month">
@@ -99,73 +101,31 @@
 <!-- )))))                                                     ((((( -->
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
 <!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month fri">1</td><td class="month sat">2</td>
-<tr class="month"><td class="month sun">3</td><td class="month mon">4</td><td class="month tue">5</td><td class="month wed">6</td><td class="month thu">7</td><td class="month fri">8</td><td class="month sat">9</td>
-<tr class="month"><td class="month sun">10</td><td class="month mon">11</td><td class="month tue">12</td><td class="month wed">13</td><td class="month thu">14</td><td class="month fri">15</td><td class="month sat">16</td>
-<tr class="month"><td class="month sun">17</td><td class="month mon">18</td><td class="month tue">19</td><td class="month wed">20</td><td class="month thu special">21</td><td class="month fri">22</td><td class="month sat">23</td>
-<tr class="month"><td class="month sun">24</td><td class="month mon">25</td><td class="month tue">26</td><td class="month wed">27</td><td class="month thu">28</td><td class="month fri">29</td><td class="month sat">30</td>
-<tr class="month"><td class="month sun">31</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
+<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month sat">1</td>
+<tr class="month"><td class="month sun">2</td><td class="month mon">3</td><td class="month tue">4</td><td class="month wed">5</td><td class="month thu issue">6</td><td class="month fri">7</td><td class="month sat">8</td>
+<tr class="month"><td class="month sun">9</td><td class="month mon">10</td><td class="month tue">11</td><td class="month wed">12</td><td class="month thu">13</td><td class="month fri">14</td><td class="month sat">15</td>
+<tr class="month"><td class="month sun">16</td><td class="month mon">17</td><td class="month tue">18</td><td class="month wed">19</td><td class="month thu">20</td><td class="month fri">21</td><td class="month sat">22</td>
+<tr class="month"><td class="month sun">23</td><td class="month mon">24</td><td class="month tue">25</td><td class="month wed">26</td><td class="month thu special">27</td><td class="month fri">28</td><td class="month sat">29</td>
+<tr class="month"><td class="month sun">30</td><td class="month mon">31</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
 </table>
 </td>
-</tr><tr>
+</tr>
+<tr>
 <td class="year"><table class="month">
 <tr><th colspan="7" class="month">September</th></tr>
 <tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
 <!-- )))))                                                     ((((( -->
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
 <!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month mon">1</td><td class="month tue">2</td><td class="month wed">3</td><td class="month thu special">4</td><td class="month fri">5</td><td class="month sat">6</td>
-<tr class="month"><td class="month sun">7</td><td class="month mon">8</td><td class="month tue">9</td><td class="month wed">10</td><td class="month thu">11</td><td class="month fri">12</td><td class="month sat">13</td>
-<tr class="month"><td class="month sun">14</td><td class="month mon">15</td><td class="month tue">16</td><td class="month wed">17</td><td class="month thu issue">18</td><td class="month fri">19</td><td class="month sat">20</td>
-<tr class="month"><td class="month sun">21</td><td class="month mon">22</td><td class="month tue">23</td><td class="month wed">24</td><td class="month thu">25</td><td class="month fri">26</td><td class="month sat">27</td>
-<tr class="month"><td class="month sun">28</td><td class="month mon">29</td><td class="month tue">30</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
+<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month tue">1</td><td class="month wed">2</td><td class="month thu">3</td><td class="month fri">4</td><td class="month sat">5</td>
+<tr class="month"><td class="month sun">6</td><td class="month mon">7</td><td class="month tue">8</td><td class="month wed">9</td><td class="month thu issue">10</td><td class="month fri">11</td><td class="month sat">12</td>
+<tr class="month"><td class="month sun">13</td><td class="month mon">14</td><td class="month tue">15</td><td class="month wed">16</td><td class="month thu">17</td><td class="month fri">18</td><td class="month sat">19</td>
+<tr class="month"><td class="month sun">20</td><td class="month mon">21</td><td class="month tue">22</td><td class="month wed">23</td><td class="month thu issue">24</td><td class="month fri">25</td><td class="month sat">26</td>
+<tr class="month"><td class="month sun">27</td><td class="month mon">28</td><td class="month tue">29</td><td class="month wed">30</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
 </table>
 </td>
 <td class="year"><table class="month">
 <tr><th colspan="7" class="month">October</th></tr>
-<tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
-<!-- )))))                                                     ((((( -->
-<!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
-<!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month wed">1</td><td class="month thu issue">2</td><td class="month fri">3</td><td class="month sat">4</td>
-<tr class="month"><td class="month sun">5</td><td class="month mon">6</td><td class="month tue">7</td><td class="month wed">8</td><td class="month thu">9</td><td class="month fri">10</td><td class="month sat">11</td>
-<tr class="month"><td class="month sun">12</td><td class="month mon">13</td><td class="month tue">14</td><td class="month wed">15</td><td class="month thu issue">16</td><td class="month fri">17</td><td class="month sat">18</td>
-<tr class="month"><td class="month sun">19</td><td class="month mon">20</td><td class="month tue">21</td><td class="month wed">22</td><td class="month thu">23</td><td class="month fri">24</td><td class="month sat">25</td>
-<tr class="month"><td class="month sun">26</td><td class="month mon">27</td><td class="month tue">28</td><td class="month wed">29</td><td class="month thu issue">30</td><td class="month fri">31</td><td class="month noday">&nbsp;</td>
-</table>
-</td>
-</tr><tr>
-<td class="year"><table class="month">
-<tr><th colspan="7" class="month">November</th></tr>
-<tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
-<!-- )))))                                                     ((((( -->
-<!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
-<!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month sat">1</td>
-<tr class="month"><td class="month sun">2</td><td class="month mon">3</td><td class="month tue">4</td><td class="month wed">5</td><td class="month thu">6</td><td class="month fri">7</td><td class="month sat">8</td>
-<tr class="month"><td class="month sun">9</td><td class="month mon">10</td><td class="month tue">11</td><td class="month wed">12</td><td class="month thu issue">13</td><td class="month fri">14</td><td class="month sat">15</td>
-<tr class="month"><td class="month sun">16</td><td class="month mon">17</td><td class="month tue">18</td><td class="month wed">19</td><td class="month thu">20</td><td class="month fri">21</td><td class="month sat">22</td>
-<tr class="month"><td class="month sun">23</td><td class="month mon">24</td><td class="month tue special">25</td><td class="month wed">26</td><td class="month thu">27</td><td class="month fri">28</td><td class="month sat">29</td>
-<tr class="month"><td class="month sun">30</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
-</table>
-</td>
-<td class="year"><table class="month">
-<tr><th colspan="7" class="month">December</th></tr>
-<tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
-<!-- )))))                                                     ((((( -->
-<!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
-<!-- )))))                                                     ((((( -->
-<tr class="month"><td class="month noday">&nbsp;</td><td class="month mon">1</td><td class="month tue">2</td><td class="month wed">3</td><td class="month thu">4</td><td class="month fri">5</td><td class="month sat">6</td>
-<tr class="month"><td class="month sun">7</td><td class="month mon">8</td><td class="month tue">9</td><td class="month wed">10</td><td class="month thu issue">11</td><td class="month fri">12</td><td class="month sat">13</td>
-<tr class="month"><td class="month sun">14</td><td class="month mon">15</td><td class="month tue">16</td><td class="month wed">17</td><td class="month thu">18</td><td class="month fri">19</td><td class="month sat">20</td>
-<tr class="month"><td class="month sun">21</td><td class="month mon">22</td><td class="month tue">23</td><td class="month wed">24</td><td class="month thu">25</td><td class="month fri">26</td><td class="month sat">27</td>
-<tr class="month"><td class="month sun">28</td><td class="month mon">29</td><td class="month tue">30</td><td class="month wed">31</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
-</table>
-</td>
-</tr><tr class="year"><th colspan="2" class="year">2026</th></tr>
-<tr>
-<td class="year"><table class="month">
-<tr><th colspan="7" class="month">January</th></tr>
 <tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
 <!-- )))))                                                     ((((( -->
 <!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
@@ -176,7 +136,54 @@
 <tr class="month"><td class="month sun">18</td><td class="month mon">19</td><td class="month tue">20</td><td class="month wed">21</td><td class="month thu issue">22</td><td class="month fri">23</td><td class="month sat">24</td>
 <tr class="month"><td class="month sun">25</td><td class="month mon">26</td><td class="month tue">27</td><td class="month wed">28</td><td class="month thu">29</td><td class="month fri">30</td><td class="month sat">31</td>
 </table>
-</td><td></td>
-</tr></table>
+</td>
+</tr>
+<tr>
+<td class="year"><table class="month">
+<tr><th colspan="7" class="month">November</th></tr>
+<tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
+<!-- )))))                                                     ((((( -->
+<!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
+<!-- )))))                                                     ((((( -->
+<tr class="month"><td class="month sun">1</td><td class="month mon">2</td><td class="month tue">3</td><td class="month wed">4</td><td class="month thu issue">5</td><td class="month fri">6</td><td class="month sat">7</td>
+<tr class="month"><td class="month sun">8</td><td class="month mon">9</td><td class="month tue">10</td><td class="month wed">11</td><td class="month thu">12</td><td class="month fri">13</td><td class="month sat">14</td>
+<tr class="month"><td class="month sun">15</td><td class="month mon">16</td><td class="month tue">17</td><td class="month wed">18</td><td class="month thu issue">19</td><td class="month fri">20</td><td class="month sat">21</td>
+<tr class="month"><td class="month sun">22</td><td class="month mon">23</td><td class="month tue">24</td><td class="month wed">25</td><td class="month thu">26</td><td class="month fri">27</td><td class="month sat">28</td>
+<tr class="month"><td class="month sun">29</td><td class="month mon">30</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
+</table>
+</td>
+<td class="year"><table class="month">
+<tr><th colspan="7" class="month">December</th></tr>
+<tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
+<!-- )))))                                                     ((((( -->
+<!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
+<!-- )))))                                                     ((((( -->
+<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month tue">1</td><td class="month wed">2</td><td class="month thu issue">3</td><td class="month fri">4</td><td class="month sat">5</td>
+<tr class="month"><td class="month sun">6</td><td class="month mon">7</td><td class="month tue">8</td><td class="month wed">9</td><td class="month thu">10</td><td class="month fri">11</td><td class="month sat">12</td>
+<tr class="month"><td class="month sun">13</td><td class="month mon">14</td><td class="month tue">15</td><td class="month wed">16</td><td class="month thu">17</td><td class="month fri">18</td><td class="month sat">19</td>
+<tr class="month"><td class="month sun">20</td><td class="month mon">21</td><td class="month tue">22</td><td class="month wed">23</td><td class="month thu">24</td><td class="month fri">25</td><td class="month sat">26</td>
+<tr class="month"><td class="month sun">27</td><td class="month mon">28</td><td class="month tue">29</td><td class="month wed">30</td><td class="month thu">31</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
+</table>
+</td>
+</tr>
+<tr class="year"><th colspan="2" class="year">2027</th></tr>
+<tr>
+<td class="year"><table class="month">
+<tr><th colspan="7" class="month">January</th></tr>
+<tr><td class="month dayname sun">S</th><td class="month dayname mon">M</th><td class="month dayname tue">T</th><td class="month dayname wed">W</th><td class="month dayname thu">T</th><td class="month dayname fri">F</th><td class="month dayname sat">S</th></tr>
+<!-- )))))                                                     ((((( -->
+<!-- ))))) **GENERATED CODE, DO NOT EDIT CALENDAR BY HAND!!!** ((((( -->
+<!-- )))))                                                     ((((( -->
+<tr class="month"><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month fri">1</td><td class="month sat">2</td>
+<tr class="month"><td class="month sun">3</td><td class="month mon">4</td><td class="month tue">5</td><td class="month wed">6</td><td class="month thu">7</td><td class="month fri">8</td><td class="month sat">9</td>
+<tr class="month"><td class="month sun">10</td><td class="month mon">11</td><td class="month tue">12</td><td class="month wed">13</td><td class="month thu">14</td><td class="month fri">15</td><td class="month sat">16</td>
+<tr class="month"><td class="month sun">17</td><td class="month mon">18</td><td class="month tue">19</td><td class="month wed">20</td><td class="month thu">21</td><td class="month fri">22</td><td class="month sat">23</td>
+<tr class="month"><td class="month sun">24</td><td class="month mon">25</td><td class="month tue">26</td><td class="month wed">27</td><td class="month thu">28</td><td class="month fri">29</td><td class="month sat">30</td>
+<tr class="month"><td class="month sun">31</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td><td class="month noday">&nbsp;</td>
+</table>
+</td>
+<td></td>
+</tr>
+</table>
 <!-- ************************************************** -->
 <!-- END GENERATED CODE! -->


### PR DESCRIPTION
Try updating the publication schedule to match 2026 dates.

Let's see if we can push updates to https://staging.thetech.com/ads/schedule. Just update the calendar for now as a really minimal change set. Based on 2026 dates.